### PR TITLE
Cleanup and description update

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,14 +20,11 @@ inputs:
     default: ''
   token:
     description: >
-      Personal access token (PAT) used to fetch the repository. The PAT is stored
-      in memory and used to ask the Github API for a list of files changed in
-      the PR.
+      GitHub automatically creates a GITHUB_TOKEN secret to use in your workflow. This input
+      is used to pass the secret to the workflow.
 
-      We recommend using a service account with the least permissions necessary.
-      Also when generating a new PAT, select the least scopes necessary.
+      [For more information reference this docs page](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token)
 
-      [Learn more about creating and using encrypted secrets](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets)
     required: false
     default: ${{ github.token }}
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
+set -euo pipefail
 
 cp /action/problem-matcher.json /github/workflow/problem-matcher.json
 
 echo "::add-matcher::${RUNNER_TEMP}/_github_workflow/problem-matcher.json"
 
-if [ -n "${INPUT_ONLY_CHANGED_FILES}" ] && [ "${INPUT_ONLY_CHANGED_FILES}" = "true" ]; then
+if [ "${INPUT_ONLY_CHANGED_FILES}" = "true" ]; then
     echo "Will only check changed files"
-    USE_CHANGED_FILES="true"
     PR="$(jq -r '.pull_request.number' < "${GITHUB_EVENT_PATH}")"
     URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR}/files"
     AUTH="Authorization: Bearer ${INPUT_TOKEN}"
@@ -15,9 +15,7 @@ if [ -n "${INPUT_ONLY_CHANGED_FILES}" ] && [ "${INPUT_ONLY_CHANGED_FILES}" = "tr
     CHANGED_FILES=$(echo "${CURL_RESULT}" | jq -r '.[] | select(.status != "removed") | .filename')
 else
     echo "Will check all files"
-    USE_CHANGED_FILES="false"
 fi
-test $? -ne 0 && echo "Could not determine changed files" && exit 1
 
 if [ -n "${INPUT_INSTALLED_PATHS}" ]; then
     ${INPUT_PHPCS_BIN_PATH} --config-set installed_paths "${INPUT_INSTALLED_PATHS}"
@@ -31,7 +29,8 @@ else
     ENABLE_WARNINGS_FLAG=""
 fi
 
-if [ "${USE_CHANGED_FILES}" = "true" ]; then
+set +e
+if [ "${INPUT_ONLY_CHANGED_FILES}" = "true" ]; then
     echo "${CHANGED_FILES}" | xargs -rt ${INPUT_PHPCS_BIN_PATH} ${ENABLE_WARNINGS_FLAG} --report=checkstyle
 else
     ${INPUT_PHPCS_BIN_PATH} ${ENABLE_WARNINGS_FLAG} --report=checkstyle

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,11 +7,9 @@ echo "::add-matcher::${RUNNER_TEMP}/_github_workflow/problem-matcher.json"
 
 if [ "${INPUT_ONLY_CHANGED_FILES}" = "true" ]; then
     echo "Will only check changed files"
-    PR="$(jq -r '.pull_request.number' < "${GITHUB_EVENT_PATH}")"
-    URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${PR}/files"
-    AUTH="Authorization: Bearer ${INPUT_TOKEN}"
+    URL="$(jq -r '.pull_request._links.self.href' "${GITHUB_EVENT_PATH}")/files"
 
-    CURL_RESULT=$(curl --request GET --url "${URL}" --header "${AUTH}")
+    CURL_RESULT=$(curl -s -H "Authorization: Bearer ${INPUT_TOKEN}" "${URL}")
     CHANGED_FILES=$(echo "${CURL_RESULT}" | jq -r '.[] | select(.status != "removed") | .filename')
 else
     echo "Will check all files"


### PR DESCRIPTION
* Updates the description of the token field with a better description pointing uses to the Github Actions documentation covering the automatic GITHUB_TOKEN usage (the previous version to me implied that I needed to go create a PAT for use with the action)
* Updates to pull the API endpoint for the PR from the event.json file and append `/files` to it rather than build the whole URL
* Updates so that shell script errors earlier in the script will trigger an immediate exit code (rather than leave potential for them to be masked)
